### PR TITLE
Update composer to include full repository in name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "php-to-go",
+  "name": "mweibel/php-to-go",
   "description": "Utility to generate go types from php models",
   "minimum-stability": "stable",
   "license": "MIT",


### PR DESCRIPTION
This is a standard in composer.json files, mostly to avoid conflicts.